### PR TITLE
fix: Use bash for preview if main shell is fish

### DIFF
--- a/bin/yayfzf
+++ b/bin/yayfzf
@@ -255,6 +255,11 @@ function _fzf() {
   SearchInput="${*}"
   [[ -n "${SearchInput}" ]] && SearchHeader="${SearchInput}" && label="${SearchInput}" || label="yayfzf"
 
+  # We need bash in order the handle the stdin redirection correctly in --preview
+  if [[ "$(basename "$SHELL")" == "fish" ]]; then
+      export SHELL="$(which bash)"
+  fi
+
   #TODO: Add --bind "ctrl-h:preview(echo '$(_yayfzf_help_full)')" \
   fzf \
     --bind 'ctrl-i:execute:yay -S $(echo {+} | cut -d" " -f1)' \


### PR DESCRIPTION
If the main shell is fish, the stdin redirection for preview fails. We
can set the shell to bash so FZF starts bash instead.

Fixes: #4
